### PR TITLE
POSIX changes that make dash happy

### DIFF
--- a/blazing_sword
+++ b/blazing_sword
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Automatically starts a Vault cluster for use in development or other
 # evaluation style use cases:
@@ -10,12 +10,12 @@
 #
 # shellcheck disable=SC2059
 
-export txtblu="\e[0;34m" # Blue
-export txtgrn="\e[0;32m" # Green
-export txtred="\e[0;31m" # Red
-export txtylw="\e[0;33m" # Yellow
-export txtwht="\e[0;37m" # White
-export txtrst="\e[0m"    # Text Reset
+export txtblu="\033[0;34m" # Blue
+export txtgrn="\033[0;32m" # Green
+export txtred="\033[0;31m" # Red
+export txtylw="\033[0;33m" # Yellow
+export txtwht="\033[0;37m" # White
+export txtrst="\033[0m"    # Text Reset
 
 ###
 ### Log stuff
@@ -117,7 +117,7 @@ _get_unseal_keys() {
 ###
 ### Get the initial root token
 ###
-function _get_initial_root_token() {
+_get_initial_root_token() {
     init_root_token=$(sed '6q;d' "${1}" | awk '{print $NF}')
 }
 

--- a/form
+++ b/form
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # shellcheck disable=SC2059
 
@@ -25,12 +25,12 @@ CURRENT_VAULT_VERSION="$(grep 'variable "vault_version"' -A2 vaultron.tf | awk '
 export TF_VAR_consul_version=${TF_VAR_consul_version:-$CURRENT_CONSUL_VERSION}
 export TF_VAR_vault_version=${TF_VAR_vault_version:-$CURRENT_VAULT_VERSION}
 
-export txtblu="\e[0;34m" # Blue
-export txtgrn="\e[0;32m" # Green
-export txtred="\e[0;31m" # Red
-export txtylw="\e[0;33m" # Yellow
-export txtwht="\e[0;37m" # White
-export txtrst="\e[0m"    # Text Reset
+export txtblu="\033[0;34m" # Blue
+export txtgrn="\033[0;32m" # Green
+export txtred="\033[0;31m" # Red
+export txtylw="\033[0;33m" # Yellow
+export txtwht="\033[0;37m" # White
+export txtrst="\033[0m"    # Text Reset
 
 ###
 ### Log stuff

--- a/unform
+++ b/unform
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 echo "🤖  Unform Vaultron ..."
 


### PR DESCRIPTION
You can test this out on mac by `brew install dash` and using, e.g. `dash ./form`. The changes are to use `#!/bin/sh` 'cause why not at this point, switch `\e` for `\033` for portable color escapes, and remove the one instance of `function` in front of a function declaration.