### PR TITLE
log tf operations, store and use the plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ vault_oss_server_2
 vault_oss_server_3
 terraform.tfstate*
 vault*.tmp
+tf-apply*.log
+tf-plan*.log
+tf-destroy*.log
+*.swp

--- a/form
+++ b/form
@@ -85,12 +85,35 @@ _check_vault_version() {
   fi
 }
 
+_tfmsg () {
+    tfmsg_out="$(echo "$1" | awk '{
+           # strip control characters for printing and matching
+           gsub(/\033\[[0-9]+m/,"")
+        }
+        /^(Apply complete|Destroy complete|Plan:)/ {
+            print "greeting"
+            print
+        }
+        /error\(s\) occurred:/ {
+            print "alert"
+            sub(/:/,"")
+            print
+        }')"
+
+    if [ -n "$tfmsg_out" ]; then
+        _logmsg "$(echo "$tfmsg_out" | head -1)" \
+                "$(echo "$tfmsg_out" | tail -1)"
+    fi
+}
+
 _apply() {
-    terraform apply -state=./tfstate/terraform.tfstate > /dev/null 2>&1;
+    _tfmsg "$(terraform apply $1 2>&1 \
+        | tee ./log/tf-apply-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log)"
 }
 
 _plan() {
-    terraform plan -state=./tfstate/terraform.tfstate > /dev/null 2>&1;
+    _tfmsg "$(terraform plan -out=$1 -state=./tfstate/terraform.tfstate 2>&1 \
+        | tee ./log/tf-plan-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log)"
 }
 
 _check_vault_version
@@ -100,8 +123,11 @@ _logmsg greeting "Form Vaultron! ..."
 _logmsg greeting "Consul version: ${TF_VAR_consul_version}"
 _logmsg greeting "Vault version: ${TF_VAR_vault_version}"
 
-if _plan; then
-    if _apply; then
+plan_file=./tfstate/vaultron-$(date -u "+%Y-%m-%dT%H:%M:%SZ").plan
+
+if _plan $plan_file; then
+    if _apply $plan_file; then
+        rm -f $plan_file
         _logmsg success "Vaultron formed!"
         printf "${txtrst}"
         _form_message

--- a/log/README.md
+++ b/log/README.md
@@ -1,0 +1,1 @@
+This is the log directory; mainly for capturing Terraform output.

--- a/unform
+++ b/unform
@@ -2,7 +2,8 @@
 
 echo "🤖  Unform Vaultron ..."
 
-terraform destroy -force -state=./tfstate/terraform.tfstate > /dev/null 2>&1
+terraform destroy -force -state=./tfstate/terraform.tfstate \
+    > ./log/tf-destroy-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log 2>&1
 errors=$?
 if [ 0 -ne $errors ]; then
     echo "🚫   Terraform destroy failed, infrastructure may still exist."


### PR DESCRIPTION
This adds logging for terraform operations into the `log/` directory. It also adds some filtering up of terraform plan and apply operation output to the user-facing output using a filter. I.e.

```
$ ./form 
✨  Form Vaultron! ...
✨  Consul version: 0.9.0
✨  Vault version: 0.7.3
✨  Plan: 11 to add, 0 to change, 0 to destroy.
✨  Apply complete! Resources: 11 added, 0 changed, 0 destroyed.
🤖  Vaultron formed!
```

Lastly, the plan is now writing a plan file to the disk, and the subsequent apply is using the created plan file.