### PR TITLE
move common things to skydome, fixes to state handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ consul_oss_server_3
 vault_oss_server_1
 vault_oss_server_2
 vault_oss_server_3
+.terraform
 terraform.tfstate*
 vault*.tmp
 tf-apply*.log

--- a/blazing_sword
+++ b/blazing_sword
@@ -10,53 +10,18 @@
 #
 # shellcheck disable=SC2059
 
-export txtblu="\033[0;34m" # Blue
-export txtgrn="\033[0;32m" # Green
-export txtred="\033[0;31m" # Red
-export txtylw="\033[0;33m" # Yellow
-export txtwht="\033[0;37m" # White
-export txtrst="\033[0m"    # Text Reset
-
-###
-### Log stuff
-###
-_logmsg() {
-    msgtype="$1"
-    msgtxt="$2"
-    case "${msgtype}" in
-        greeting)
-            printf "✨  ${txtylw}${msgtxt}\n"
-            ;;
-        info)
-            printf "ℹ️  ${txtblu}${msgtxt}\n"
-            ;;
-        success)
-            printf "✅  ${txtgrn}${msgtxt}\n"
-            ;;
-        notice)
-            printf "✴️  ${txtylw}${msgtxt}\n"
-            ;;
-        alert)
-            printf "🚫  ${txtred}${msgtxt}\n" >&2
-            ;;
-        *)
-            printf "⁉️  ${txtwht}${msgtxt}\n" >&2
-            ;;
-    esac
-}
+. ./skydome
 
 ###
 ### Check for the existence of a temporary key material file
 ###
 _check_vault_file() {
-    for file in vault_*.tmp
-        do
-            if [ -e "$file" ];
-                then
-                    _logmsg info "Existing Vault file detected; pass filename as first argument and it will be used for unsealing."
-                    exit 0
-            fi
-        done
+    for file in vault_*.tmp; do
+        if [ -e "$file" ]; then
+            _logmsg info "Existing Vault file detected; pass filename as first argument and it will be used for unsealing."
+            exit 0
+        fi
+    done
 }
 
 ###
@@ -80,7 +45,7 @@ _auth_root() {
 ### Enable audit log
 ###
 _enable_audit_logging() {
-    _logmsg success "Enabled file based audit log at ./vault/logs/audit.log!"
+    _logmsg complete "Enabled file based audit log at ./vault/logs/audit.log!"
     _auth_root
     vault audit-enable file file_path=/vault/logs/audit.log  > /dev/null 2>&1
 }
@@ -92,17 +57,17 @@ _enable_auth_backends() {
     _logmsg info "Enabling Vault authentication backends ..."
     _auth_root
     vault auth-enable app-id > /dev/null 2>&1
-    _logmsg success "Enabled App ID authentication backend!"
+    _logmsg complete "Enabled App ID authentication backend!"
     vault auth-enable approle > /dev/null 2>&1
-    _logmsg success "Enabled AppRole authentication backend!"
+    _logmsg complete "Enabled AppRole authentication backend!"
     # TODO:
     # This needs to be conditionally added based on installed Vault version
     #vault auth-enable aws > /dev/null 2>&1
-    #_logmsg success "Enabled AWS authentication backend!"
+    #_logmsg complete "Enabled AWS authentication backend!"
     vault auth-enable ldap > /dev/null 2>&1
-    _logmsg success "Enabled LDAP authentication backend!"
+    _logmsg complete "Enabled LDAP authentication backend!"
     vault auth-enable userpass > /dev/null 2>&1
-    _logmsg success "Enabled Username & Password authentication backend!"
+    _logmsg complete "Enabled Username & Password authentication backend!"
 }
 
 ###
@@ -132,7 +97,7 @@ _initialize_vault() {
     vault_init_now="$(date)"
     printf "\nGenerated on %s\n" "${vault_init_now}" >> \
            "${vault_dat}"
-    _logmsg success "Vault initialized!"
+    _logmsg complete "Vault initialized!"
 }
 
 ###
@@ -142,19 +107,19 @@ _mount_secret_backends() {
     _logmsg info "Mounting Vault secret backends ..."
     _get_initial_root_token "${vault_dat}"
     vault mount aws > /dev/null 2>&1
-    _logmsg success "Mounted AWS secret backend!"
+    _logmsg complete "Mounted AWS secret backend!"
     vault mount consul > /dev/null 2>&1
-    _logmsg success "Mounted Consul secret backend!"
+    _logmsg complete "Mounted Consul secret backend!"
     vault mount pki > /dev/null 2>&1
-    _logmsg success "Mounted PKI secret backend!"
+    _logmsg complete "Mounted PKI secret backend!"
     vault mount postgresql > /dev/null 2>&1
-    _logmsg success "Mounted PostgreSQL secret backend!"
+    _logmsg complete "Mounted PostgreSQL secret backend!"
     vault mount transit > /dev/null 2>&1
-    _logmsg success "Mounted Transit secret backend!"
+    _logmsg complete "Mounted Transit secret backend!"
     vault mount -path ssh-host-signer ssh > /dev/null 2>&1
-    _logmsg success "Mounted SSH host signer backend!"
+    _logmsg complete "Mounted SSH host signer backend!"
     vault mount -path ssh-client-signer ssh > /dev/null 2>&1
-    _logmsg success "Mounted SSH client signer backend!"
+    _logmsg complete "Mounted SSH client signer backend!"
 }
 
 ###
@@ -162,8 +127,7 @@ _mount_secret_backends() {
 ###
 _status() {
     _logmsg info "Vault status ..."
-    vault status
-    printf "${txtrst}"
+    printf "${txtblu}$(vault status)${txtrst}"
 }
 
 ###

--- a/form
+++ b/form
@@ -2,6 +2,8 @@
 
 # shellcheck disable=SC2059
 
+. ./skydome
+
 _form_message () {
 cat << 'EOF'
 Now that Vaultron is formed, you can visit the Consul web UI
@@ -15,49 +17,6 @@ export VAULT_ADDR="http://localhost:8200"
 
 Then you can use the vault and consul commands as needed.
 EOF
-}
-
-
-CURRENT_CONSUL_VERSION="$(echo "var.consul_version" | terraform console)"
-
-CURRENT_VAULT_VERSION="$(echo "var.vault_version" | terraform console)"
-
-export TF_VAR_consul_version=${TF_VAR_consul_version:-$CURRENT_CONSUL_VERSION}
-export TF_VAR_vault_version=${TF_VAR_vault_version:-$CURRENT_VAULT_VERSION}
-
-export txtblu="\033[0;34m" # Blue
-export txtgrn="\033[0;32m" # Green
-export txtred="\033[0;31m" # Red
-export txtylw="\033[0;33m" # Yellow
-export txtwht="\033[0;37m" # White
-export txtrst="\033[0m"    # Text Reset
-
-###
-### Log stuff
-###
-_logmsg() {
-    msgtype="$1"
-    msgtxt="$2"
-    case "${msgtype}" in
-        greeting)
-            printf "✨  ${txtylw}${msgtxt}\n"
-            ;;
-        info)
-            printf "ℹ️  ${txtblu}${msgtxt}\n"
-            ;;
-        success)
-            printf "🤖  ${txtgrn}${msgtxt}\n"
-            ;;
-        notice)
-            printf "✴️  ${txtylw}${msgtxt}\n"
-            ;;
-        alert)
-            printf "🚫  ${txtred}${msgtxt}\n" >&2
-            ;;
-        *)
-            printf "⁉️  ${txtwht}${msgtxt}\n" >&2
-            ;;
-    esac
 }
 
 ###
@@ -85,57 +44,41 @@ _check_vault_version() {
   fi
 }
 
-_tfmsg () {
-    tfmsg_out="$(echo "$1" | awk '{
-           # strip control characters for printing and matching
-           gsub(/\033\[[0-9]+m/,"")
-        }
-        /^(Apply complete|Destroy complete|Plan:)/ {
-            print "greeting"
-            print
-        }
-        /error\(s\) occurred:/ {
-            print "alert"
-            sub(/:/,"")
-            print
-        }')"
+_logmsg greeting "Form Vaultron! ..."
 
-    if [ -n "$tfmsg_out" ]; then
-        _logmsg "$(echo "$tfmsg_out" | head -1)" \
-                "$(echo "$tfmsg_out" | tail -1)"
-    fi
-}
+_init
+if [ 0 -ne $? ]; then
+    _logmsg alert "Vaultron cannot form! Check terraform init output."
+    exit 1
+fi
 
-_apply() {
-    _tfmsg "$(terraform apply $1 2>&1 \
-        | tee ./log/tf-apply-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log)"
-}
+CURRENT_CONSUL_VERSION="$(echo "var.consul_version" | terraform console)"
+CURRENT_VAULT_VERSION="$(echo "var.vault_version" | terraform console)"
 
-_plan() {
-    _tfmsg "$(terraform plan -out=$1 -state=./tfstate/terraform.tfstate 2>&1 \
-        | tee ./log/tf-plan-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log)"
-}
+export TF_VAR_consul_version=${TF_VAR_consul_version:-$CURRENT_CONSUL_VERSION}
+export TF_VAR_vault_version=${TF_VAR_vault_version:-$CURRENT_VAULT_VERSION}
 
 _check_vault_version
 _check_consul_version
 
-_logmsg greeting "Form Vaultron! ..."
 _logmsg greeting "Consul version: ${TF_VAR_consul_version}"
 _logmsg greeting "Vault version: ${TF_VAR_vault_version}"
 
 plan_file=./tfstate/vaultron-$(date -u "+%Y-%m-%dT%H:%M:%SZ").plan
 
-if _plan $plan_file; then
-    if _apply $plan_file; then
-        rm -f $plan_file
-        _logmsg success "Vaultron formed!"
-        printf "${txtrst}"
-        _form_message
-    else
-        _logmsg alert "Vaultron cannot form! Check terraform apply output."
-        printf "${txtrst}"
-    fi
-else
+_plan $plan_file
+if [ 0 -ne $? ]; then
     _logmsg alert "Vaultron cannot form! Check terraform plan output."
-    printf "${txtrst}"
+    exit 1
 fi
+
+_apply $plan_file
+if [ 0 -ne $? ]; then
+    _logmsg alert "Vaultron cannot form! Check terraform apply output."
+    exit 1
+fi
+
+rm -f $plan_file
+_logmsg success "Vaultron formed!"
+_form_message
+

--- a/skydome
+++ b/skydome
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+# shellcheck disable=SC2059
+
+txtblu="\033[0;34m" # Blue
+txtgrn="\033[0;32m" # Green
+txtred="\033[0;31m" # Red
+txtylw="\033[0;33m" # Yellow
+txtwht="\033[0;37m" # White
+txtrst="\033[0m"    # Text Reset
+
+###
+### Log stuff
+###
+_logmsg() {
+    msgtype="$1"
+    msgtxt="$2"
+    case "${msgtype}" in
+        greeting)
+            printf "✨  ${txtylw}${msgtxt}\n"
+            ;;
+        info)
+            printf "ℹ️  ${txtblu}${msgtxt}\n"
+            ;;
+        success)
+            printf "🤖  ${txtgrn}${msgtxt}\n"
+            ;;
+        complete)
+            printf "✅  ${txtgrn}${msgtxt}\n"
+            ;;
+        boom)
+            printf "💥  ${txtwht}${msgtxt}\n" >&2
+            ;;
+        notice)
+            printf "✴️  ${txtylw}${msgtxt}\n"
+            ;;
+        alert)
+            printf "🚫  ${txtred}${msgtxt}\n" >&2
+            ;;
+        *)
+            printf "⁉️  ${txtwht}${msgtxt}\n" >&2
+            ;;
+    esac
+    printf "${txtrst}"
+}
+
+_tfmsg() {
+    tfmsg_out="$(echo "$1" | awk '{
+           # strip control characters for printing and matching
+           gsub(/\033\[[0-9]+m/,"")
+        }
+        /^(Apply complete|Destroy complete|Plan:|Terraform.*initialized!)/ {
+            print "greeting"
+            print
+            exit
+        }
+        /^([0-9]+ error\(s\) occurred:|Failed to load backend)/ {
+            print "alert"
+            sub(/:.*/,"")
+            print
+            exit
+        }')"
+
+    if [ -n "$tfmsg_out" ]; then
+        _logmsg "$(echo "$tfmsg_out" | head -1)" \
+                "$(echo "$tfmsg_out" | tail -1)"
+    fi
+}
+
+_init() {
+    tfout="$(terraform init 2>&1)"
+    ret=$?
+    echo "$tfout" > ./log/tf-init-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log
+    _tfmsg "$tfout"
+    return $ret
+}
+
+_apply() {
+    tfout="$(terraform apply $1 2>&1)"
+    ret=$?
+    echo "$tfout" > ./log/tf-apply-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log
+    _tfmsg "$tfout"
+    return $ret
+}
+
+_plan() {
+    tfout="$(terraform plan -out=$1 2>&1)"
+    ret=$?
+    echo "$tfout" > ./log/tf-plan-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log
+    _tfmsg "$tfout"
+    return $ret
+}
+
+_destroy() {
+    tfout="$(terraform destroy -force -state=./tfstate/terraform.tfstate 2>&1)"
+    echo "$tfout" > ./log/tf-destroy-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log
+    _tfmsg "$tfout"
+    return $ret
+}
+

--- a/unform
+++ b/unform
@@ -1,12 +1,13 @@
 #!/bin/sh
 
-echo "🤖  Unform Vaultron ..."
+. ./skydome
 
-terraform destroy -force -state=./tfstate/terraform.tfstate \
-    > ./log/tf-destroy-$(date -u "+%Y-%m-%dT%H:%M:%SZ").log 2>&1
+_logmsg success "Unform Vaultron ..."
+
+_destroy
 errors=$?
 if [ 0 -ne $errors ]; then
-    echo "🚫   Terraform destroy failed, infrastructure may still exist."
+    _logmsg alter "Terraform destroy failed, infrastructure may still exist."
 fi
 
 ###
@@ -42,15 +43,19 @@ rm -rf ./vault/vault_*.tmp
 errors=$(( $errors + $?))
 
 ###
-### Remove Terraform state
+### Remove Terraform state, plans, and backend configs
 ###
 rm -rf ./tfstate/terraform.tfstate*
 errors=$(( $errors + $?))
+rm -rf ./tfstate/vaultron*.plan
+errors=$(( $errors + $?))
+rm -rf ./.terraform
+errors=$(( $errors + $?))
 
 if [ $errors -gt 0 ]; then
-    echo "💥  Vaultron unformed (with $errors errors)!"
+    _logmsg boom "Vaultron unformed (with $errors errors)!"
 else
-    echo "💥  Vaultron unformed!"
+    _logmsg boom "Vaultron unformed!"
 fi
 
 exit $errors

--- a/vaultron.tf
+++ b/vaultron.tf
@@ -6,6 +6,12 @@
 ### Global variables
 ###
 
+terraform {
+  backend "local" {
+    path = "tfstate/terraform.tfstate"
+  }
+}
+
 # "This is fine"
 provider "docker" {
   host = "unix:///var/run/docker.sock"


### PR DESCRIPTION
OK!

* Created `skydome`, moved common things into there, including logging, text coloring, plan/apply/init terraform commands
* Fix state handling (it seems like `-state` doesn't work with `plan` like expected) by moving to using the `local` backend and `init`.
* Always reset console output after a log message, so it doesn't need to be reset when exiting.