### PR TITLE
remove interpolations to prevent warnings

### DIFF
--- a/black_lion/main.tf
+++ b/black_lion/main.tf
@@ -166,7 +166,7 @@ resource "docker_container" "vault_oss_server" {
 
   networks_advanced {
     name         = "vaultron-network"
-    ipv4_address = "${format("10.10.42.20%d", count.index)}"
+    ipv4_address = format("10.10.42.20%d", count.index)
   }
 
   volumes {
@@ -306,7 +306,7 @@ resource "docker_container" "vault_custom_server" {
 
   networks_advanced {
     name         = "vaultron-network"
-    ipv4_address = "${format("10.10.42.20%d", count.index)}"
+    ipv4_address = format("10.10.42.20%d", count.index)
   }
 
   volumes {

--- a/red_lion/main.tf
+++ b/red_lion/main.tf
@@ -519,7 +519,7 @@ resource "docker_container" "consul_oss_client" {
 
   networks_advanced {
     name         = "vaultron-network"
-    ipv4_address = "${format("10.10.42.4%d", count.index)}"
+    ipv4_address = format("10.10.42.4%d", count.index)
   }
 
   upload {


### PR DESCRIPTION
expressions that contain nothing but functions and expressions, and do not require string interpolations, should no longer be enclosed in `${ ... }`. These generate a warning now and can cause Vaultron to fail to form with Terraform 0.12.10.